### PR TITLE
Added board display on main page

### DIFF
--- a/lib/board.dart
+++ b/lib/board.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/widgets.dart';
 
+import 'cell.dart';
 import 'model/game.dart';
 
 class BoardView extends StatelessWidget {
@@ -8,6 +9,20 @@ class BoardView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Placeholder();
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          for(final row in board)
+            Row(
+              children: [
+                for(final column in row)
+                  Cell(0, state: column),
+              ],
+            ),
+        ],
+      )],
+    );
   }
 }

--- a/lib/cell.dart
+++ b/lib/cell.dart
@@ -3,31 +3,53 @@ import 'package:flutter/material.dart';
 import 'model/game.dart';
 
 class Cell extends StatefulWidget {
-  const Cell(CellState s, int i, {super.key});
+  const Cell(int i, {super.key, this.state = CellState.x});
+
+  final CellState state;
 
   @override
-  State<Cell> createState() => _CellState();
+  State<Cell> createState() => _CellState(state);
 }
 
 class _CellState extends State<Cell> {
-  CellState _state = CellState.x;
+  _CellState(this._state);
+
+  CellState _state;
   static const _size = 40.0;
 
   void handleTap() {
     switch (_state) {
       case CellState.x:
-        _state = CellState.o;
-        break;
       case CellState.o:
-        _state = CellState.empty;
+      case CellState.outside:
         break;
       case CellState.empty:
         _state = CellState.x;
         break;
-      case CellState.outside:
-        break;
     }
     setState(() {});
+  }
+
+  Widget _getIcon() {
+    switch (_state) {
+      case CellState.x:
+      case CellState.o:
+        return Icon(_state.icon);
+      case CellState.empty:
+      case CellState.outside:
+        return const Text('');
+    }
+  }
+
+  Color _getBorderColor() {
+    switch (_state) {
+      case CellState.x:
+      case CellState.o:
+      case CellState.empty:
+        return Colors.black;
+      case CellState.outside:
+        return Colors.transparent;
+    }
   }
 
   @override
@@ -36,11 +58,11 @@ class _CellState extends State<Cell> {
       onTap: handleTap,
       child: Container(
         decoration: BoxDecoration(
-          border: Border.all(color: Colors.blueAccent),
+          border: Border.all(color:_getBorderColor(), width: 0),
         ),
         width: _size,
         height: _size,
-        child: Icon(_state.icon),
+        child: _getIcon(),
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:tic_tac_toe/board.dart';
 
 import 'model/boards.dart';
-import 'model/game.dart';
 
 void main() {
   runApp(const MyApp());
@@ -19,8 +18,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.pink,
       ),
-      home: const MyHomePage(
-          grid: defaultGridIdx),
+      home: const MyHomePage(grid: defaultGridIdx),
     );
   }
 }
@@ -58,19 +56,21 @@ class _MyHomePageState extends State<MyHomePage> {
             child: Center(
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
+                mainAxisSize: MainAxisSize.min,
                 children: <Widget>[
                   Text(
                     boards.keys.elementAt(widget.grid),
                     style: Theme.of(context).textTheme.headlineMedium,
                   ),
                   const SizedBox(height: 20),
-                  BoardView(board: boards.entries.first.value),
+                  BoardView(board: boards.entries.toList()[widget.grid].value),
                   const SizedBox(height: 20),
                   ElevatedButton(
                     onPressed: () {
                       Navigator.push(
                         context,
-                        MaterialPageRoute(builder: (context) => const GridsPage()),
+                        MaterialPageRoute(
+                            builder: (context) => const GridsPage()),
                       );
                     },
                     child: const Text('Choose grid'),


### PR DESCRIPTION
Added board display on main page.
- when click on an empty cell, it becomes 'x'
- when click on 'x', it does nothing
- when click on outside cell, it does nothing

[Board.zip](https://github.com/flutter-chat-dev/tic_tac_toe/files/11046867/Board.zip)
